### PR TITLE
Modify observer to constantly look out for videos on the current tab

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -14,20 +14,25 @@ chrome.storage.sync.get('playbackspeed', ({ playbackspeed }) => {
 
 /** 
  * Configures an observer to look out for changes in the DOM with relation to video tag.
- * Once found, adjust video speed accordingly and stop observing.
+ * Once found, adjust video speed accordingly.
  */
 observer = new MutationObserver(function(mutations) {
 	mutations.forEach(function(mutation) {
 		mutation.addedNodes.forEach(node => {
-			video = node.querySelector('video');
-			
-			if (video != null && video.tagName == 'VIDEO') {
-				video.addEventListener('loadeddata', (event) => {
-					video.playbackRate = speed;
-					console.log('Video found using mutation observer, adjusting speed to ' + speed + 'x');
-				});
-				observer.disconnect();
-			}
+		    try {
+		        var video = node.querySelector('video');
+
+		        if (video != null && video.tagName == 'VIDEO') {
+		            video.addEventListener('loadeddata', (event) => {
+                        video.playbackRate = speed;
+                        console.log('Video found using mutation observer, adjusting speed to ' + speed + 'x');
+                    });
+		        }
+		    } catch (error) {
+		        if (error instanceof TypeError) {
+		            console.log('Node changes is not a HTML element!');
+		        }
+		    }
 		});
 	});
 });


### PR DESCRIPTION
Currently the video extension only looks out for a single video on the webpage and stops thereafter. This update enables the extension to be observing for videos that may appear on the current tab. 